### PR TITLE
rdns-forwarder EBS enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- rdns-forwarder: EBS encryption with the default alias/aws/ebs KMS key.
+- rdns-forwarder: EBS volume type changed to gp3.
 
 
 ## [0.11.2] - 2021-12-20

--- a/modules/rdns-forwarder/module.tf
+++ b/modules/rdns-forwarder/module.tf
@@ -222,6 +222,10 @@ data "aws_vpc" "selected" {
   id = data.aws_subnet.selected.vpc_id
 }
 
+data "aws_kms_key" "aws_ebs" {
+  key_id = "alias/aws/ebs"
+}
+
 # fail fast if instance_type and instance_architecture are incompatible
 data "aws_ec2_instance_type" "this" {
   instance_type = var.instance_type
@@ -284,6 +288,14 @@ resource "aws_instance" "forwarder" {
   vpc_security_group_ids      = [aws_security_group.rdns.id]
   iam_instance_profile        = aws_iam_instance_profile.instance_profile.name
   user_data_base64            = data.cloudinit_config.user_data.rendered
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 8
+
+    encrypted  = true
+    kms_key_id = data.aws_kms_key.aws_ebs.arn
+  }
 
   lifecycle {
     # Avoids unnecessary destruction and recreation of the instance by


### PR DESCRIPTION
Add two changes to rdns-forwarder EBS root volumes:

- Enable encrypted volumes with the alias/aws/ebs KMS key.
- Switch volume type to newer gp3.

People upgrading their terraforms will see that existing rdns-forwarder instances will need to be recreated. Changing EBS encryption is a destructive operation.